### PR TITLE
Added public key retrieval support and fixed a bug

### DIFF
--- a/Android/app/src/androidTest/java/teamzero/chat/mobile/JSONConstructorInstrumentedTests.java
+++ b/Android/app/src/androidTest/java/teamzero/chat/mobile/JSONConstructorInstrumentedTests.java
@@ -22,8 +22,8 @@ public class JSONConstructorInstrumentedTests {
     public void registrationJSONisValid() {
         JSONConstructor jsonConstructor = new JSONConstructor();
         try {
-            assertEquals(null, "{\"type\":\"REGISTER\",\"username\":\"UsernameTest\",\"password\":\"PwdTest\",\"email\":\"testEmail@gmail.com\",\"picture\":\"null\"}", jsonConstructor.constructRegisterJSON("UsernameTest", "PwdTest", "testEmail@gmail.com", "null"));
-            assertEquals(null, "{\"type\":\"REGISTER\",\"username\":\"UsernameTest\",\"password\":\"PwdTest\",\"email\":\"testEmail@gmail.com\"}", jsonConstructor.constructRegisterJSON("UsernameTest", "PwdTest", "testEmail@gmail.com", null));
+            assertEquals(null, "{\"type\":\"REGISTER\",\"username\":\"UsernameTest\",\"password\":\"PwdTest\",\"email\":\"testEmail@gmail.com\",\"picture\":\"null\",\"publicKey\":\"testPublicKey\"}", jsonConstructor.constructRegisterJSON("UsernameTest", "PwdTest", "testEmail@gmail.com", "null", "testPublicKey"));
+            assertEquals(null, "{\"type\":\"REGISTER\",\"username\":\"UsernameTest\",\"password\":\"PwdTest\",\"email\":\"testEmail@gmail.com\"}", jsonConstructor.constructRegisterJSON("UsernameTest", "PwdTest", "testEmail@gmail.com", null, null));
         } catch (JSONException e) {
             e.printStackTrace();
         }
@@ -63,8 +63,8 @@ public class JSONConstructorInstrumentedTests {
     public void editProfileJSONisValid() {
         JSONConstructor jsonConstructor = new JSONConstructor();
         try {
-            assertEquals(null, "{\"type\":\"EDIT\",\"username\":\"UsernameTest\",\"newPicture\":\"null\"}", jsonConstructor.constructEditProfileJSON("UsernameTest", "null"));
-            assertEquals(null, "{\"type\":\"EDIT\",\"username\":\"UsernameTest\"}", jsonConstructor.constructEditProfileJSON("UsernameTest", null));
+            assertEquals(null, "{\"type\":\"EDIT\",\"username\":\"UsernameTest\",\"newPicture\":\"null\",\"publicKey\":\"testPublicKey\"}", jsonConstructor.constructEditProfileJSON("UsernameTest", "null", "testPublicKey"));
+            assertEquals(null, "{\"type\":\"EDIT\",\"username\":\"UsernameTest\"}", jsonConstructor.constructEditProfileJSON("UsernameTest", null, null));
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/Android/app/src/main/java/database/StoredChatList.java
+++ b/Android/app/src/main/java/database/StoredChatList.java
@@ -18,8 +18,8 @@ public class StoredChatList implements Serializable {
     @ColumnInfo(name = "last_message_content")
     private String lastMessageContent;
 
-    @ColumnInfo(name = "last_message_date")
-    private String lastMessageDate;
+    @ColumnInfo(name = "public_key")
+    private String publicKey;
 
     /* *
      *
@@ -51,12 +51,12 @@ public class StoredChatList implements Serializable {
         this.lastMessageContent = lastMessageContent;
     }
 
-    public String getLastMessageDate() {
-        return lastMessageDate;
+    public String getPublicKey() {
+        return publicKey;
     }
 
-    public void setLastMessageDate(String messageDate) {
-        this.lastMessageDate = lastMessageDate;
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
     }
 
 }

--- a/Android/app/src/main/java/database/StoredChatList.java
+++ b/Android/app/src/main/java/database/StoredChatList.java
@@ -21,6 +21,12 @@ public class StoredChatList implements Serializable {
     @ColumnInfo(name = "public_key")
     private String publicKey;
 
+    @ColumnInfo(name = "shared_secret_key")
+    private String sharedSecretKey;
+
+    @ColumnInfo(name = "chat_belongs_to")
+    private String chatBelongsTo;
+
     /* *
      *
      * Getters and Setters
@@ -59,4 +65,15 @@ public class StoredChatList implements Serializable {
         this.publicKey = publicKey;
     }
 
+    public String getSharedSecretKey() { return sharedSecretKey; }
+
+    public void setSharedSecretKey(String sharedSecretKey) {
+        this.sharedSecretKey = sharedSecretKey;
+    }
+
+    public String getChatBelongsTo() { return chatBelongsTo; }
+
+    public void setChatBelongsTo(String chatBelongsTo) {
+        this.chatBelongsTo = chatBelongsTo;
+    }
 }

--- a/Android/app/src/main/java/database/StoredChatListDao.java
+++ b/Android/app/src/main/java/database/StoredChatListDao.java
@@ -16,8 +16,14 @@ public interface StoredChatListDao {
     @Query("SELECT * FROM storedchatlist")
     List<StoredChatList> getAll();
 
+    @Query("SELECT * FROM storedchatlist WHERE chat_belongs_to LIKE :username")
+    List<StoredChatList> getChatsForClient(String username);
+
     @Query("DELETE FROM storedchatlist")
     void deleteAll();
+
+    @Query("DELETE FROM storedchatlist WHERE chat_belongs_to LIKE :username")
+    void deleteAllChatsForClient(String username);
 
     @Insert
     void insert(StoredChatList storedChatList);

--- a/Android/app/src/main/java/teamzero/chat/mobile/ChatList.java
+++ b/Android/app/src/main/java/teamzero/chat/mobile/ChatList.java
@@ -94,7 +94,8 @@ public class ChatList extends AppCompatActivity {
 
                 UserDetails.chatWith = storedChatList.get(position).getUsername();
 
-                // TODO: Start Activity --> Goto chat page with X person
+                System.out.println(UserDetails.chatWith + " 's Public Key = " + storedChatList.get(position).getPublicKey());
+
                 startActivity(new Intent(ChatList.this, Chat.class));
             }
         });
@@ -303,6 +304,7 @@ public class ChatList extends AppCompatActivity {
             @Override
             protected List<StoredChatList> doInBackground(Void... voids) {
                 // DELETE FROM storedchatlist
+                System.out.println("Deleting all chats (doInBackground)");
                 AppDatabaseClient
                         .getInstance(getApplicationContext())
                         .getAppDatabase()
@@ -315,7 +317,7 @@ public class ChatList extends AppCompatActivity {
             protected void onPostExecute(List<StoredChatList> scl) {
                 super.onPostExecute(scl);
                 // Refresh
-                startActivity(new Intent(ChatList.this, ChatList.class));
+                System.out.println("Deleting all chats (onPostExecute)");
             }
         }
 

--- a/Android/app/src/main/java/teamzero/chat/mobile/ChatList.java
+++ b/Android/app/src/main/java/teamzero/chat/mobile/ChatList.java
@@ -117,12 +117,12 @@ public class ChatList extends AppCompatActivity {
 
             @Override
             protected List<StoredChatList> doInBackground(Void... voids) {
-                // SELECT * FROM storedchatlist
+                // SELECT * FROM storedchatlist WHERE chat_belongs_to LIKE UserDetails.username
                 List<StoredChatList> scl = AppDatabaseClient
                         .getInstance(getApplicationContext())
                         .getAppDatabase()
                         .storedChatListDao()
-                        .getAll();
+                        .getChatsForClient(UserDetails.username);
                 return scl;
             }
 
@@ -309,7 +309,7 @@ public class ChatList extends AppCompatActivity {
                         .getInstance(getApplicationContext())
                         .getAppDatabase()
                         .storedChatListDao()
-                        .deleteAll();
+                        .deleteAllChatsForClient(UserDetails.username);
                 return null;
             }
 

--- a/Android/app/src/main/java/teamzero/chat/mobile/NewChat.java
+++ b/Android/app/src/main/java/teamzero/chat/mobile/NewChat.java
@@ -118,9 +118,9 @@ public class NewChat extends AppCompatActivity {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
 
-                addUserToStoredChatList(usersFoundList.get(position).getUsername());
-
-                startActivity(new Intent(NewChat.this, ChatList.class));
+                addUserToStoredChatList(usersFoundList.get(position).getUsername(),
+                                        usersFoundList.get(position).getPublicKey());
+                finish();
             }
         });
     }
@@ -196,7 +196,7 @@ public class NewChat extends AppCompatActivity {
 
     }
 
-    private void addUserToStoredChatList(final String searchUsersEditTextString) {
+    private void addUserToStoredChatList(final String searchUsersEditTextString, final String publicKeyOfUser) {
 
         // TODO: Add the user only if it does not exist already in local database
 
@@ -208,8 +208,7 @@ public class NewChat extends AppCompatActivity {
                 StoredChatList scl = new StoredChatList();
                 scl.setUsername(searchUsersEditTextString);
                 scl.setLastMessageContent("Last message here");
-                scl.setLastMessageDate(null);
-                // TODO: Add the public key of that specific user to the local database
+                scl.setPublicKey(publicKeyOfUser);
 
                 // Add the user into the local chat list database
                 AppDatabaseClient.getInstance(getApplicationContext()).getAppDatabase()
@@ -222,7 +221,7 @@ public class NewChat extends AppCompatActivity {
             protected void onPostExecute(Void aVoid) {
                 super.onPostExecute(aVoid);
                 finish();
-                startActivity(new Intent(getApplicationContext(), ChatList.class));
+                //startActivity(new Intent(getApplicationContext(), ChatList.class));
                 Toast.makeText(getApplicationContext(), "Chat created", Toast.LENGTH_LONG).show();
             }
         }

--- a/Android/app/src/main/java/teamzero/chat/mobile/NewChat.java
+++ b/Android/app/src/main/java/teamzero/chat/mobile/NewChat.java
@@ -209,6 +209,9 @@ public class NewChat extends AppCompatActivity {
                 scl.setUsername(searchUsersEditTextString);
                 scl.setLastMessageContent("Last message here");
                 scl.setPublicKey(publicKeyOfUser);
+                // TODO: Compute shared secret key
+                scl.setSharedSecretKey(null);
+                scl.setChatBelongsTo(UserDetails.username);
 
                 // Add the user into the local chat list database
                 AppDatabaseClient.getInstance(getApplicationContext()).getAppDatabase()

--- a/Android/app/src/main/java/teamzero/chat/mobile/NewChat.java
+++ b/Android/app/src/main/java/teamzero/chat/mobile/NewChat.java
@@ -143,6 +143,13 @@ public class NewChat extends AppCompatActivity {
                 oud.setUsername(x.get("username").toString());
                 oud.setStatus(x.get("IsLoggedIn").toString().equalsIgnoreCase("true") ? "online" : "offline");
 
+                // If the public key exists, set it explicitly. Else, default will be empty string
+                if(x.has("publicKey"))
+                    oud.setPublicKey(x.get("publicKey").toString());
+                else oud.setPublicKey("");
+
+                //System.out.println(oud.getUsername() + " = " + oud.getPublicKey());
+
                 usersFoundList.add(oud);
             }
         } catch(JSONException e) {
@@ -202,6 +209,7 @@ public class NewChat extends AppCompatActivity {
                 scl.setUsername(searchUsersEditTextString);
                 scl.setLastMessageContent("Last message here");
                 scl.setLastMessageDate(null);
+                // TODO: Add the public key of that specific user to the local database
 
                 // Add the user into the local chat list database
                 AppDatabaseClient.getInstance(getApplicationContext()).getAppDatabase()

--- a/Android/app/src/main/java/teamzero/chat/mobile/Registration.java
+++ b/Android/app/src/main/java/teamzero/chat/mobile/Registration.java
@@ -70,8 +70,12 @@ public class Registration extends AppCompatActivity {
 
         try {
 
+            // TODO: Create tool method that generates public key according to the encryption algorithm
+            // TODO: Create tool method that generates private key according to the encryption algorithm
+            String publicKey = "testPublicKey", privateKey = "testPrivateKey";
+
             // Send register JSON request to server
-            WebSocketHandler.getSocket().sendMessageAndWait(new JSONConstructor().constructRegisterJSON(username, password, email, picture), false);
+            WebSocketHandler.getSocket().sendMessageAndWait(new JSONConstructor().constructRegisterJSON(username, password, email, picture, publicKey), false);
 
             //Thread.sleep(500);
 

--- a/Android/app/src/main/java/teamzero/chat/mobile/WebSocket.java
+++ b/Android/app/src/main/java/teamzero/chat/mobile/WebSocket.java
@@ -36,7 +36,7 @@ public class WebSocket {
         try {
             // Used the following URI for testing purposes only
             // TODO: Change URI to Heroku server
-            uri = new URI("ws://10.200.194.182:1234");
+            uri = new URI("ws://10.200.199.236:1234");
         } catch (URISyntaxException e) {
             e.printStackTrace();
             return;

--- a/Android/app/src/main/java/teamzero/chat/mobile/WebSocket.java
+++ b/Android/app/src/main/java/teamzero/chat/mobile/WebSocket.java
@@ -36,7 +36,7 @@ public class WebSocket {
         try {
             // Used the following URI for testing purposes only
             // TODO: Change URI to Heroku server
-            uri = new URI("ws://10.200.199.236:1234");
+            uri = new URI("ws://10.200.204.203:1234");
         } catch (URISyntaxException e) {
             e.printStackTrace();
             return;

--- a/Android/app/src/main/java/teamzero/chat/mobile/WebSocket.java
+++ b/Android/app/src/main/java/teamzero/chat/mobile/WebSocket.java
@@ -36,7 +36,7 @@ public class WebSocket {
         try {
             // Used the following URI for testing purposes only
             // TODO: Change URI to Heroku server
-            uri = new URI("ws://10.200.198.140:1234");
+            uri = new URI("ws://10.200.194.182:1234");
         } catch (URISyntaxException e) {
             e.printStackTrace();
             return;

--- a/Android/app/src/main/java/tools/JSONConstructor.java
+++ b/Android/app/src/main/java/tools/JSONConstructor.java
@@ -14,13 +14,14 @@ public class JSONConstructor {
     private String builtJSON;
     private JSONObject jsonObject = new JSONObject();
 
-    public String constructRegisterJSON(String username, String password, String email, Object picture) throws JSONException {
+    public String constructRegisterJSON(String username, String password, String email, Object picture, String publicKey) throws JSONException {
 
         jsonObject.put("type", "REGISTER");
         jsonObject.put("username", username);
         jsonObject.put("password", password);
         jsonObject.put("email", email);
         jsonObject.put("picture", picture);
+        jsonObject.put("publicKey", publicKey);
 
         builtJSON = jsonObject.toString();
         return builtJSON;
@@ -56,11 +57,12 @@ public class JSONConstructor {
         return builtJSON;
     }
 
-    public String constructEditProfileJSON(String username, Object newPicture) throws JSONException {
+    public String constructEditProfileJSON(String username, Object newPicture, String publicKey) throws JSONException {
 
         jsonObject.put("type", "EDIT");
         jsonObject.put("username", username);
         jsonObject.put("newPicture", newPicture);
+        jsonObject.put("publicKey", publicKey);
 
         builtJSON = jsonObject.toString();
         return builtJSON;

--- a/Android/app/src/main/java/users/data/OtherUsersData.java
+++ b/Android/app/src/main/java/users/data/OtherUsersData.java
@@ -7,6 +7,7 @@ public class OtherUsersData {
     private String lastMessageContent = "";
     private String lastMessageTime = "";
     private String avatar = "";
+    private String publicKey = "";
 
     public String getUsername() {
         return username;
@@ -46,6 +47,12 @@ public class OtherUsersData {
 
     public void setAvatar(String avatar) {
         this.avatar = avatar;
+    }
+
+    public String getPublicKey() { return publicKey; }
+
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
     }
 
 }


### PR DESCRIPTION
1) Modified the request JSONs for `Register` and `Edit` actions
2) Added support for retrieval of public keys and store them on the local database
3) Added shared_secret_key and chat_belongs_to to the Stored Chat List table
4) Fixed a bug where multiple Runnable instances are opened when the user returns to the main Chat List page
5) Fixed a bug where all the chats were deleted for all the users instead of the user that started this action