### PR TITLE
Ordered Chat History and Added Delay

### DIFF
--- a/TeamZeroServer/src/server/DbConnection.java
+++ b/TeamZeroServer/src/server/DbConnection.java
@@ -305,7 +305,7 @@ public class DbConnection {
 						+ " FROM chat_message "
 						+ "INNER JOIN users AS u1 ON (u1.user_id=chat_message.sender_id) "
 						+ "INNER JOIN users AS u2 ON (u2.user_id=chat_message.recipient_id)"
-						+ " WHERE chat_id = ? AND timesent between ? AND ?;");
+						+ " WHERE chat_id = ? AND timesent between ? AND ? ORDER BY timesent ASC;");
 				ps.setInt(1, chatId);
 				ps.setTimestamp(2, Timestamp.valueOf(limitStr));
 				ps.setTimestamp(3, Timestamp.valueOf(nowStr));

--- a/TeamZeroServer/src/server/ServerMain.java
+++ b/TeamZeroServer/src/server/ServerMain.java
@@ -713,6 +713,13 @@ public class ServerMain extends WebSocketServer {
 			return;
 		}
 		
+		try {
+			Thread.sleep(10);
+		} catch (InterruptedException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
 		Iterator<String> iterator = messagesToSend.iterator();
 		//TODO: currently sends as separate messages. it may be preferable to send a single larger
 		// message with all the data?


### PR DESCRIPTION
- Ordered the response for `GETCHATHISTORY` by timestamp
- Added a small sleep period on the concurrent threads before sending previously unsent messages while a user was offline in order to avoid crashes on the client side