### PR TITLE
Server dev

### DIFF
--- a/ServerTesterClient/src/GroupCreateMethodsTestStrings.java
+++ b/ServerTesterClient/src/GroupCreateMethodsTestStrings.java
@@ -119,7 +119,7 @@ public class GroupCreateMethodsTestStrings {
 		return jsonMsg;
 	}
 
-	public String searchContactsMessage(String search) {
+	public String searchGroupsMessage(String search) {
 		String jsonMsg = 
 				"{\"type\": \"SEARCHGROUPS\"" +
 				", \"search\": \"" + search + "\"}";

--- a/ServerTesterClient/src/GroupCreateMethodsTestStrings.java
+++ b/ServerTesterClient/src/GroupCreateMethodsTestStrings.java
@@ -6,18 +6,18 @@ public class GroupCreateMethodsTestStrings {
 
 	private String password1 = "testpassword";
 
-	private String groupName1 = "testGroupName";
+	private String groupName1 = "AnotherTestGroupName001";
 
-	private String groupName3 = "testGroupName3";
-	private String groupName2 = "testGroupName2";
+	private String groupName3 = "AnotherTestGroupName3";
+	private String groupName2 = "AnotherTestGroupName2";
 	
 	private String username2 = "t02";
 
-	private String username3 = "t03";
+	private String username3 = "t04";
 	
 	private String password2 = "testpassword2";	
 	
-	private String password3 = "testpassword";
+	private String password3 = "testpassword4";
 	
 
 	public String getClient1GroupCreateMessage() {
@@ -106,7 +106,7 @@ public class GroupCreateMethodsTestStrings {
 		String jsonMsg =  
 				"{\"type\": \"GROUPTEXT\"" + 
 				", \"sender\":\"" + username1 + 
-				"\", \"recipient\":\"" + groupName1 + 
+				"\", \"groupName\":\"" + groupName1 + 
 				"\", \"message\":\"message from test client 1 to test group 1.\"}";  
 		return jsonMsg;
 		
@@ -139,7 +139,7 @@ public class GroupCreateMethodsTestStrings {
 		String jsonMsg =  
 				"{\"type\": \"GROUPTEXT\"" + 
 				", \"sender\":\"" + username2 + 
-				"\", \"recipient\":\"" + groupName1 + 
+				"\", \"groupName\":\"" + groupName1 + 
 				"\", \"message\":\"message from test client 2 to test group 1.\"}";  
 		return jsonMsg;
 		

--- a/ServerTesterClient/src/GroupTest.java
+++ b/ServerTesterClient/src/GroupTest.java
@@ -60,6 +60,8 @@ public class GroupTest extends WebSocketClient{
 		this.send(groupTester.getClient2JoinGroupMessage());
 
 		this.send(groupTester.getClient2GroupCreateMessage());
+		
+		this.send(groupTester.getClient3JoinGroupMessage());
 
 		this.send(groupTester.getGetAllGroupsMessage());
 
@@ -73,7 +75,9 @@ public class GroupTest extends WebSocketClient{
 		
 
 		this.send(groupTester.getGetAllGroupsMessage());
-		this.send(groupTester.searchGroupsMessage("3"));
+		this.send(groupTester.searchGroupsMessage("001"));
+		this.send(groupTester.getClient1ToGroup1TextMessage());
+		this.send(groupTester.getClient2ToGroupTextMessage());
 		
 
 		

--- a/ServerTesterClient/src/GroupTest.java
+++ b/ServerTesterClient/src/GroupTest.java
@@ -59,6 +59,8 @@ public class GroupTest extends WebSocketClient{
 
 		this.send(groupTester.getClient2JoinGroupMessage());
 
+		this.send(groupTester.getClient2GroupCreateMessage());
+
 		this.send(groupTester.getGetAllGroupsMessage());
 
 		this.send(groupTester.getClient3GroupCreateMessage());
@@ -71,6 +73,7 @@ public class GroupTest extends WebSocketClient{
 		
 
 		this.send(groupTester.getGetAllGroupsMessage());
+		this.send(groupTester.searchGroupsMessage("3"));
 		
 
 		

--- a/TeamZeroServer/src/server/DbConnection.java
+++ b/TeamZeroServer/src/server/DbConnection.java
@@ -397,8 +397,6 @@ public class DbConnection {
 		ArrayList<Group> allGroups = new ArrayList<Group>();
 		Connection conn = this.connect();
 		try {
-			
-			//TODO fix this - currently it is not getting the members
 			PreparedStatement ps = conn.prepareStatement("SELECT g.group_id as group_id, g.group_name as group_name, u.members"
 					+ " FROM groups g, LATERAL ( SELECT ARRAY ( "
 					+ "SELECT u.username "
@@ -428,8 +426,6 @@ public class DbConnection {
 		ArrayList<Group> searchedGroups = new ArrayList<Group>();
 		Connection conn = this.connect();
 		try {
-			
-			//TODO fix this - currently it is not getting the members
 			PreparedStatement ps = conn.prepareStatement("SELECT g.group_id as group_id, g.group_name as group_name, u.members"
 					+ " FROM groups g, LATERAL ( SELECT ARRAY ( "
 					+ "SELECT u.username "

--- a/TeamZeroServer/src/server/DbConnection.java
+++ b/TeamZeroServer/src/server/DbConnection.java
@@ -353,25 +353,31 @@ public class DbConnection {
 					throw new SQLException("Groupname already exists");
 				}
 			} else {
-				ps = conn.prepareStatement("INSERT INTO GROUPS (group_name,number_of_members) VALUES (?, ?)");
-				ps.setString(1, groupName);
-				ps.setInt(2, MAX_NUMBER_OF_MEMBERS);
-				ps.executeUpdate();
+				PreparedStatement ps1 = conn.prepareStatement("INSERT INTO GROUPS (group_name,number_of_members) VALUES (?, ?) RETURNING group_id");
+				ps1.setString(1, groupName);
+				ps1.setInt(2, MAX_NUMBER_OF_MEMBERS);
+				ResultSet result = ps1.executeQuery();
+
+				 LOGGER.log(Level.FINE, "Created new group {0}", groupName);
 				
-				rs = ps.getGeneratedKeys(); // get the newly created group Id
+				 // get the newly created group Id
 				int groupId = 0;
-				if (rs.next()) {
-					 groupId = rs.getInt(1);
+				if (result.next()) {
+					 groupId = result.getInt(1);
+				
+				// insert the userId and groupId into user_groups table as well
+				// this user is also a member of the group they created
+					 LOGGER.log(Level.FINE, "Adding group creator {0} to group", creatingUser);
+					 ps1 = conn.prepareStatement("INSERT INTO user_groups (user_id,group_id) VALUES (?, ?)");
+					 ps1.setInt(1, getUserIDFromUsername(creatingUser));
+					 ps1.setInt(2, groupId);
+					 ps1.executeUpdate();
+					 LOGGER.log(Level.FINE, "Added group {0}", groupName);
+					 success = true;
+					 ps1.close();
 				}
-				// insert the userId and groupId into user_groups table
-
-				ps = conn.prepareStatement("INSERT INTO user_groups (user_id,group_id) VALUES (?, ?)");
-				ps.setInt(1, getUserIDFromUsername(creatingUser));
-				ps.setInt(2, groupId);
-
-				LOGGER.log(Level.FINE, "Added group {0}", groupName);
-				success = true;
 			}
+			
 			ps.close();
 			conn.close();
 		} catch (SQLException e) {
@@ -413,6 +419,7 @@ public class DbConnection {
 			e.printStackTrace();
 			throw e;
 		}
+		LOGGER.log(Level.FINE, "Getting all groups: {0}", allGroups);
 		return allGroups;
 	}
 	
@@ -448,10 +455,19 @@ public class DbConnection {
 		return searchedGroups;
 	}
 	
-	//TODO
-	public void addGroupMessage(String sender, String groupName, String message, String timestamp) throws SQLException {
+	
+	/**
+	 * Adds a group text message to the database
+	 * @param sender the user sending the message
+	 * @param groupName the group receiving the message
+	 * @param message the contents of the text message 
+	 * @param timestamp the time the user sent the message (as received by the server)
+	 * @return An arraylist of client usernames that the message needs to be sent to
+	 * @throws SQLException
+	 */
+	public ArrayList<String> addGroupMessage(String sender, String groupName, String message, String timestamp) throws SQLException {
+		ArrayList<String> groupMembers = new ArrayList<String>();
 		Connection conn = connect();
-		int chatId = 0;
 		try {
 			
 			// check that the sender is a member of the group
@@ -466,14 +482,25 @@ public class DbConnection {
 			ResultSet rs = ps.executeQuery();
 			if (rs.next()) {
 				
-				chatId = rs.getInt(COLUMN_CHAT_ID);
 				ps = conn.prepareStatement(
-						"INSERT INTO groupt_message (sender_id,group_id,timesent,message_content) VALUES (?, ?, ?, ?)");
+						"INSERT INTO group_message (sender_id,group_id,timesent,message_content) VALUES (?, ?, ?, ?)");
 				ps.setInt(1, senderId);
 				ps.setInt(2, groupId);
 				ps.setTimestamp(3, Timestamp.valueOf(timestamp));
 				ps.setString(4, message);
 				ps.executeUpdate();
+				
+				// Get all clients in the group except for the client that sent the message
+				ps = conn.prepareStatement("SELECT username from users LEFT JOIN user_groups on users.user_id = user_groups.user_id WHERE group_id = ?;");
+				ps.setInt(1, groupId);
+				rs = ps.executeQuery();
+				while(rs.next()) {
+					String userName = rs.getString(COLUMN_USERNAME);
+					if (userName != sender) {
+						groupMembers.add(userName);
+					}
+				}
+				
 				ps.close();
 			} else {
 				// a group with this user does not exist
@@ -488,6 +515,12 @@ public class DbConnection {
 			e.printStackTrace();
 			throw e;
 		}
+		return groupMembers;
+	}
+	
+	// TODO
+	public boolean removeGroupMember(String groupName, String username) throws SQLException{
+			return false;
 	}
 	
 	/**
@@ -508,15 +541,28 @@ public class DbConnection {
 			if (rs.next()) {
 				int groupId = rs.getInt(COLUMN_GROUP_ID);
 				
-				// TODO check number of users with group_id is not more than MAX_NUMBER_OF_MEMBERS
-				//add user to user groups table
-				ps = conn.prepareStatement("INSERT INTO user_groups (user_id,group_id) VALUES (?, ?)");
-				ps.setInt(1, getUserIDFromUsername(username));
-				ps.setInt(2, groupId);
-
-				LOGGER.log(Level.FINE, "Added user to group {0}", groupName);
-				success = true;
+				// check if user does not already exist in the group.
+				int userId = getUserIDFromUsername(username);
+				ps = conn.prepareStatement("SELECT * FROM user_groups WHERE group_id = ? AND user_id = ?;");
+				ps.setInt(1, groupId);
+				ps.setInt(2, userId);
+				rs = ps.executeQuery();
 				
+				if (!rs.next()) {
+					// TODO check number of users with group_id is not more than MAX_NUMBER_OF_MEMBERS
+					//add user to user groups table
+					ps = conn.prepareStatement("INSERT INTO user_groups (user_id,group_id) VALUES (?, ?)");
+					ps.setInt(1, getUserIDFromUsername(username));
+					ps.setInt(2, groupId);
+
+					ps.executeUpdate();
+					LOGGER.log(Level.FINE, "Added user to group {0}", groupName);
+					success = true;
+				}
+				else {
+					//user already exists in this group
+					success = false;
+				}
 			} else {
 				// groupName does not exist
 				throw new SQLException("Group name does not exist.");		
@@ -622,7 +668,7 @@ public class DbConnection {
 			ps.setString(1, groupName);
 			ResultSet rs = ps.executeQuery();
 			if (rs.next()) {
-				int groupId = rs.getInt(COLUMN_ID);
+				int groupId = rs.getInt(COLUMN_GROUP_ID);
 				ps.close();
 				conn.close();
 				return groupId;

--- a/TeamZeroServer/src/server/ServerMain.java
+++ b/TeamZeroServer/src/server/ServerMain.java
@@ -459,14 +459,14 @@ public class ServerMain extends WebSocketServer {
 				case CASE_GROUP_TEXT:
 					// check if user is authenticated
 					if (isAuthenticated(websocket)) {
-						userName = json.getString(JSON_KEY_USERNAME);
+						userName = json.getString(JSON_KEY_SENDER);
 						String groupName = json.getString(JSON_KEY_GROUPNAME);
 						String groupText = json.getString(JSON_KEY_MESSAGE);
 						 
 						String ts = DATE_FORMAT.format(new Date());
-						dbConnection.addGroupMessage(userName, groupName, groupText, ts);
+						ArrayList<String> memberUserNames = dbConnection.addGroupMessage(userName, groupName, groupText, ts);
 						json.put(JSON_KEY_TIMESTAMP, ts);
-						sendClientText(websocket, json);
+						sendGroupText(websocket, json, memberUserNames);
 						 
 					}
 					else {
@@ -586,6 +586,69 @@ public class ServerMain extends WebSocketServer {
 		Client c = ClientManager.getInstance().getClientById(id);
 		if (c == null) return false;
 		return  c.isLoggedIn();
+	}
+	
+	private void sendGroupText(WebSocket websocket, JSONObject message, ArrayList<String> memberUserNames) throws JSONException{
+		/*
+		 * expecting the following json
+
+			{
+				type: GROUPTEXT
+				sender: fromUsername
+				groupName: groupName
+				message: message
+				timestamp: datetime
+			}
+		*/
+		
+		// get member details
+		for (int i = 0; i < memberUserNames.size(); i++) {
+			Client recipient = ClientManager.getInstance().getClientByUsername(memberUserNames.get(i));
+			String recipientUsername = recipient.getUsername();
+			WebSocket recipientSocket = null;
+			
+			if (recipient != null) {
+				recipientSocket = getWebSocketByClientId(recipient.getId());
+			}
+			if (recipientSocket != null) {
+				// if recipient is connected, send message right away
+					recipientSocket.send(message.toString());
+					LOGGER.log( Level.FINE, 
+							"Group message sent to recipient {0}", recipientUsername);
+			}
+			else {
+				// if recipient is not currently connected
+				// insert message into unsent messages map
+		
+				ArrayList<String> unsentMessages;
+				
+				// check if there already are any unsent messages
+				if (recipientUnsentMessages.containsKey(recipientUsername)){
+					unsentMessages = recipientUnsentMessages.get(recipientUsername);
+					unsentMessages.add(message.toString());
+					
+					// but the updated array list back in the map
+					recipientUnsentMessages.put(recipientUsername, unsentMessages);
+					LOGGER.log( Level.FINE, 
+							"Group message added to unsent messages map for recipient {0}", recipientUsername);
+				}
+				else { 
+					// if there are no previous messages, add a new array with one message
+					unsentMessages = new ArrayList<String>();
+					unsentMessages.add(message.toString());
+					recipientUnsentMessages.put(recipientUsername, unsentMessages);	
+					LOGGER.log( Level.FINE, 
+							"New unsent messages map created for recipient {0} to receive group message", recipientUsername);
+				}
+				
+			}		
+		}
+		websocket.send(
+				generateReplyToClient(
+						CASE_GROUP_TEXT,
+					MESSAGE_REPLY_SUCCESS, 	
+						"Message sent to group."));
+		
 	}
 	
 	

--- a/TeamZeroServer/src/server/ServerMain.java
+++ b/TeamZeroServer/src/server/ServerMain.java
@@ -521,7 +521,7 @@ public class ServerMain extends WebSocketServer {
 						ArrayList<Group> searchedGroups = dbConnection.getSearchedGroups(search);
 						JSONObject searchGroupsReply = new JSONObject();
 						searchGroupsReply.put(JSON_KEY_MESSAGE_TYPE, MESSAGE_REPLY);
-						searchGroupsReply.put(MESSAGE_REPLY, CASE_GETALLGROUPS + ": SUCCESS");
+						searchGroupsReply.put(MESSAGE_REPLY, CASE_SEARCHGROUPS + ": SUCCESS");
 						for(Group g : searchedGroups) {
 							JSONObject group = new JSONObject();
 							group.put(JSON_KEY_GROUPNAME, g.getGroupName());


### PR DESCRIPTION
Group chat API is now functional:

- **CREATEGROUP** (user will automatically join the group, no need to separately send JOINGROUP request)

- **JOINGROUP** - simply joins a group given the groupname. No request/accept system at the moment.

- **GETALLGROUPS** - returns a list of all the groups in the system, and the members in the groups

- **SEARCHGROUPS** - similar to searching users, searches the groups for a like query and returns a list of groups and their members

- **GROUPTEXT** - send a text message to the group. This will then be sent to all the other users who are members of the group. (whether this text will be encrypted or not, and how etc, depends entirely on whether the clients encrypt the messages or not - as the server does not determine this!). Similar to regular user texts, this will save texts in a message map and send them on login if the user is offline at the time.


Deleting a group, removing a user from a group, blocking a user from entering a group or a request/accept system, and other more advanced functionality is not (yet) implemented. 